### PR TITLE
Configure TypeScript compiler (#3)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,39 @@
 {
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictTemplates": true
+  },
   "compilerOptions": {
+    "allowJs": false,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "alwaysStrict": true,
     "declaration": false,
     "downlevelIteration": true,
+    "exactOptionalPropertyTypes": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "lib": ["ES2022", "dom"],
     "module": "ES2022",
     "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "./dist/out-tsc",
+    "removeComments": true,
     "sourceMap": true,
+    "strict": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": false, // difficult to use angular with this rule enabled
     "target": "ES2022",
+    "useUnknownInCatchVariables": true
   }
 }


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/9

In the scope of adding Angular (#1) we've also added minimal typescript configuration required for angular to run the app.

As a part of adding linters configuration story (https://github.com/fenya123/bingin/issues/9) we should configure our typescript compiler checks to strict as possible to find all possible typing errors.

In the scope of this task we need to go through all available TS compiler checks from [docs](https://www.typescriptlang.org/tsconfig) and add useful ones in our `tsconfig.json`.