### PR TITLE
Add linters to CI (#9)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+run-name: Lint commit "${{ github.sha }}"
+
+on:
+  push:
+    branches:
+      - "*"
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build lint
+        run: docker compose --file envs/ci/lint/docker-compose.yml build lint
+
+      - name: Run lint
+        run: docker compose --file envs/ci/lint/docker-compose.yml run lint

--- a/envs/ci/lint/Dockerfile
+++ b/envs/ci/lint/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16.14.0-slim
+
+WORKDIR /acih-frontend
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . ./

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the current file to the project root dir
+      dockerfile: envs/ci/lint/Dockerfile  # path from the project root dir to the Dockerfile
+
+  lint:
+    <<: *app-build
+    entrypoint: npm run lint


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/11

As a part of setting up CI pipeline for frontend, after we've set up our linters and plugins, we have to add a pipeline which will run in GitHub environment and check linters output, to prevent us from merging code with linter issues to main branch.

In the scope of this task we have to add GitHub workflow which runs our linters on GitHub, and set up repository to prevent PRs from being merged if some linter errors were reported.