### PR TITLE
Add build step to CI (#16)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,20 @@
+name: Build
+run-name: Build commit "${{ github.sha }}"
+
+on:
+  push:
+    branches:
+      - "*"
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build build
+        run: docker compose --file envs/ci/build/docker-compose.yml build build
+
+      - name: Run build
+        run: docker compose --file envs/ci/build/docker-compose.yml run build

--- a/envs/ci/build/Dockerfile
+++ b/envs/ci/build/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16.14.0-slim
+
+WORKDIR /acih-frontend
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . ./

--- a/envs/ci/build/docker-compose.yml
+++ b/envs/ci/build/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the current file to the project root dir
+      dockerfile: envs/ci/build/Dockerfile  # path from the project root dir to the Dockerfile
+
+  build:
+    <<: *app-build
+    entrypoint: npm run build


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/11

Our CI pipeline should also check whether the application can be built or not, to not merge PRs with failed build accidentally.

In the scope of this task we have to add application build step to our existing CI pipeline.